### PR TITLE
dicom conversion utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.swo
 *.swp
 .DS_Store
+data/dicom/**/*
+data/image/**/*
+!data/**/README.md

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@
 *.swo
 *.swp
 .DS_Store
-data/dicom/**/*
-data/image/**/*
+data/**/*
+data/**/*
 !data/**/README.md

--- a/data/dicom/README.md
+++ b/data/dicom/README.md
@@ -1,0 +1,2 @@
+Put directories containing dicom files here. The dicom_utils script will look in
+here for files to convert/get pixel data from.

--- a/data/image/README.md
+++ b/data/image/README.md
@@ -1,0 +1,2 @@
+dicom_utils script will generate a directory structure here matching the original
+structure but converting each dicom file to an image.

--- a/data/image/README.md
+++ b/data/image/README.md
@@ -1,2 +1,0 @@
-dicom_utils script will generate a directory structure here matching the original
-structure but converting each dicom file to an image.

--- a/src/dicom_utils.py
+++ b/src/dicom_utils.py
@@ -1,0 +1,21 @@
+import os
+import pydicom
+
+DICOM_DATA_DIR = '../data/dicom'
+
+def get_pixels(fname):
+    """Returns a 2d numpy containing the pixel values of a dicom image"""
+    dicom_dataset = pydicom.read_file(fname)
+    return dicom_dataset.pixel_array
+
+def pixels_iterator(data_dir=DICOM_DATA_DIR):
+    for root, dirs, files in os.walk(data_dir):
+        for fname in files:
+            if fname.endswith('.md') or fname == '.DS_Store': # ugly but works
+                continue
+            yield get_pixels(os.path.join(root, fname))
+
+def generate_jpgs(data_dir=DICOM_DATA_DIR):
+    for root, dirs, files in os.walk(data_dir):
+        for fname in files:
+            yield

--- a/src/dicom_utils.py
+++ b/src/dicom_utils.py
@@ -1,21 +1,69 @@
+import numpy as np
 import os
+import png
 import pydicom
 
+
 DICOM_DATA_DIR = '../data/dicom'
+DICOM_IMAGE_DIR = '../data/image'
 
-def get_pixels(fname):
-    """Returns a 2d numpy containing the pixel values of a dicom image"""
-    dicom_dataset = pydicom.read_file(fname)
-    return dicom_dataset.pixel_array
+def get_dicom_dataset(fname):
+    """Returns a pydiom.FileDataset object corresponding to a single dicom file"""
+    try:
+        return pydicom.read_file(fname, force=True)
+    except Exception as e:
+        print(e)
+        return None
 
-def pixels_iterator(data_dir=DICOM_DATA_DIR):
+def data_iterator(data_dir=DICOM_DATA_DIR):
+    """Iterator that walks a directory tree loading dicom files"""
     for root, dirs, files in os.walk(data_dir):
+        print("processing %s files" % str(len(files)))
         for fname in files:
             if fname.endswith('.md') or fname == '.DS_Store': # ugly but works
                 continue
-            yield get_pixels(os.path.join(root, fname))
+            file_path = os.path.join(root, fname)
+            dataset = get_dicom_dataset(file_path)
+            if dataset is None:
+                continue
+            yield (file_path, dataset)
 
-def generate_jpgs(data_dir=DICOM_DATA_DIR):
-    for root, dirs, files in os.walk(data_dir):
-        for fname in files:
-            yield
+def get_min_shape():
+    """Get the minimum dimension of images in our dataset. Maybe useful for
+    downsizing later."""
+    min_width, min_height = None, None
+    for _, dataset in data_iterator():
+        try:
+            pixels = dataset.pixel_array
+            if min_height is None or pixels.shape[0] < min_height:
+                min_height = pixels.shape[0]
+            if min_width is None or pixels.shape[1] < min_width:
+                min_width = pixels.shape[1]
+        except Exception as e:
+            continue
+    return (min_height, min_width)
+
+def generate_data():
+    num_success, num_failures = 0, 0
+    image_index = 1
+    for path, dataset in data_iterator():
+        try:
+            pixels = dataset.pixel_array
+        except Exception as e:
+            print('exception: %s' % str(e))
+            num_failures += 1
+            if num_failures % 100 == 0:
+                print("%s failures" % str(num_failures))
+            continue
+        pixels_scaled = np.uint((np.maximum(pixels, 0) / pixels.max()) * 255)
+        w = png.Writer(pixels.shape[1], pixels.shape[0], greyscale=True)
+        with open(os.path.join(DICOM_IMAGE_DIR, str(image_index) + '.png'), 'wb') as f:
+            if len(pixels_scaled.shape) == 2:
+                w.write(f, pixels_scaled)
+                image_index += 1
+                num_success += 1
+    print('num success: %s' % str(num_success))
+    print('num failures: %s' % str(num_failures))
+
+if __name__ == '__main__':
+    generate_data()

--- a/src/environment.yml
+++ b/src/environment.yml
@@ -9,3 +9,4 @@ dependencies:
   - python=3.6
   - pip:
     - pydicom
+    - pypng


### PR DESCRIPTION
Some quick n dirty code which generates pngs from some dicom files

Assumes a directory structure as described in the data/**/README.md
files. Running the dicom_utils script will generate a bunch of jpegs
corresponding to *some* of the dicom files it finds in the directory
tree.

It is still unable to load anything from the 1st dataset, I believe
because the image data is formatted slightly differently. (I have an idea of how to fix this.) However, it does work
on most of the files in the second dataset.

The dicom files have a decent amount of other metadata in them as
well--I recommend loading up some of the files and looking through the
metadata fields.

A few definite TOODs from here:
* Come up with a file naming scheme/directory structure which will be
easy to consume with code and also easy to understand which images come
from the same patients/the same dates

* Fix the conversion failures

* Maybe make the dicom_utils script also output a csv of the non-image
metadata?